### PR TITLE
Fixed #6 -- Setup the django registry on load

### DIFF
--- a/aldryn_celery/celery.py
+++ b/aldryn_celery/celery.py
@@ -1,17 +1,22 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import os
+import sys
 import aldryn_django.startup
 
 from celery import Celery
 
+from django.conf import settings
 
-# `path` is not used anymore but still required
-aldryn_django.startup._setup(path=None)
+# Adds the current directory to python path.
+# This is required for django to find the settings module
+sys.path.insert(0, os.getcwd())
 
-from django.conf import settings  # noqa
+# Sets DJANGO_SETTINGS_MODULE environment variable
+# Calls django.setup() to setup app registry
+aldryn_django.startup.setup(path=None)
 
 app = Celery('aldryn_celery')
-
-app.config_from_object('django.conf:settings')
+app.config_from_object(settings)
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/aldryn_celery/cli.py
+++ b/aldryn_celery/cli.py
@@ -1,16 +1,15 @@
 #-*- coding: utf-8 -*-
 from __future__ import absolute_import
-import click
+
 import os
-import sys
+
+import click
+
 from django.conf import settings as django_settings
-
-
-# add the current directory to pythonpath. So the project files can be read.
 from django.core.exceptions import ImproperlyConfigured
 
+
 BASE_DIR = os.getcwd()
-sys.path.insert(0, BASE_DIR)
 
 
 @click.command()
@@ -46,9 +45,6 @@ def beat(ctx_obj):
 def main(ctx, verbose):
     if not os.path.exists(os.path.join(BASE_DIR, 'manage.py')):
         raise click.UsageError('make sure you are in the same directory as manage.py')
-
-    from aldryn_django import startup
-    startup._setup(BASE_DIR)
 
     ctx.obj = {
         'settings': {key: getattr(django_settings, key) for key in dir(django_settings)}


### PR DESCRIPTION
The` cli.py` file is loaded after `celery.py`
When `cli.py` is loaded, it adds `/app` to the python path and then sets django's settings module env variable.

The problem is that when cam starts, it loads the orm because it uses django models and loading the orm requires django's app registry which was never setup (`django.setup()`).

Setting up django's registry was troublesome because of the order in which these modules are loaded, so the solution is to add `/app` to the `PYTHONPATH` in the `celery.py` file and **then** setup django's registry.