### PR TITLE
Fixed a setup loop when starting the server

### DIFF
--- a/aldryn_celery/celery.py
+++ b/aldryn_celery/celery.py
@@ -9,13 +9,16 @@ from celery import Celery
 
 from django.conf import settings
 
-# Adds the current directory to python path.
-# This is required for django to find the settings module
-sys.path.insert(0, os.getcwd())
+
+BASE_DIR = os.getcwd()
+
+if BASE_DIR not in sys.path:
+    # Adds the current directory to python path.
+    # This is required for django to find the settings module
+    sys.path.insert(0, BASE_DIR)
 
 # Sets DJANGO_SETTINGS_MODULE environment variable
-# Calls django.setup() to setup app registry
-aldryn_django.startup.setup(path=None)
+aldryn_django.startup._setup(path=None)
 
 app = Celery('aldryn_celery')
 app.config_from_object(settings)

--- a/aldryn_celery/cli.py
+++ b/aldryn_celery/cli.py
@@ -5,6 +5,7 @@ import os
 
 import click
 
+import django
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -51,6 +52,9 @@ def main(ctx, verbose):
     }
     if not ctx.obj['settings'].get('ENABLE_CELERY'):
         raise ImproperlyConfigured('Celery is not enabled.')
+
+    # Setup app registry
+    django.setup()
 
 
 main.add_command(worker)


### PR DESCRIPTION
Delay the setup of django to when the specific celery commands are run.
This avoids a loop where aldryn-django tries to setup the project as well.